### PR TITLE
add generating save files and loading them back in with toml serialization and deserialization

### DIFF
--- a/src/gamemaker.rs
+++ b/src/gamemaker.rs
@@ -24,6 +24,7 @@ fn handle_user_action() -> GameState {
 
         let user_action = tools::read_input();
 
+        println!();
         match user_action.as_str() {
             "exit" => return GameState::QuitGame,
             "start up screen" => return GameState::StartUpScreen,

--- a/src/gamemaker.rs
+++ b/src/gamemaker.rs
@@ -42,7 +42,6 @@ pub fn main_loop(arg_file: Option<String>) {
         }
         None => start_up_screen(),
     };
-    // add load save here if available
     loop {
         // should have a shell reset here to keep things clean
         for _ in 0..3 {
@@ -69,11 +68,11 @@ fn start_up_screen() -> GameState {
 /// Guides user through quiz, prompts for every question and returns result upon completion.
 fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
     match saved_quiz {
-        None => {
+        None => {}
+        Some(_) => {
             println!("We have a saved quiz!!");
             return handle_user_action();
         }
-        Some(_) => (),
     }
     let quizes = riddler::Quizes::setup_single_examination();
     let mut quiz: Option<riddler::Quiz>;
@@ -102,7 +101,6 @@ fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
     if let Some(score) = riddler::Quiz::take_quiz(quiz.clone()) {
         riddler::Quiz::show_result(score, quiz.questions.len() as i32);
     } else {
-        println!("Progress saved, into file at src dir.");
         return GameState::QuitGame;
     }
 

--- a/src/gamemaker.rs
+++ b/src/gamemaker.rs
@@ -35,6 +35,7 @@ fn handle_user_action() -> GameState {
 
 // main loop for switching between game states
 pub fn main_loop(arg_file: Option<String>) {
+    tools::clear_terminal();
     let mut game_state: GameState = match arg_file {
         Some(file_path) => {
             let loaded_quiz: SavedQuiz = load_single_exam_save_file(file_path);
@@ -43,10 +44,8 @@ pub fn main_loop(arg_file: Option<String>) {
         None => start_up_screen(),
     };
     loop {
-        // should have a shell reset here to keep things clean
-        for _ in 0..3 {
-            println!(); // TODO: replace with bash reset
-        }
+        tools::clear_terminal();
+
         game_state = match game_state {
             GameState::StartUpScreen => start_up_screen(),
             GameState::SingleExamination => single_examination(None),

--- a/src/gamemaker.rs
+++ b/src/gamemaker.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use rust_quiz_game::riddler::{self, load_single_exam_save_file, SavedQuiz};
 
 #[path = "tools.rs"]
@@ -35,16 +37,17 @@ fn handle_user_action() -> GameState {
 
 // main loop for switching between game states
 pub fn main_loop(arg_file: Option<String>) {
-    tools::clear_terminal();
+    //     tools::clear_terminal();
     let mut game_state: GameState = match arg_file {
-        Some(file_path) => {
+        Some(arg_file) => {
+            let file_path: &Path = Path::new(&arg_file);
             let loaded_quiz: SavedQuiz = load_single_exam_save_file(file_path);
             single_examination(Some(loaded_quiz))
         }
         None => start_up_screen(),
     };
     loop {
-        tools::clear_terminal();
+        //     tools::clear_terminal();
 
         game_state = match game_state {
             GameState::StartUpScreen => start_up_screen(),
@@ -70,6 +73,8 @@ fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
         None => {}
         Some(_) => {
             println!("We have a saved quiz!!");
+            let quiz = saved_quiz.unwrap();
+            println!("{:?}", quiz);
             return handle_user_action();
         }
     }

--- a/src/gamemaker.rs
+++ b/src/gamemaker.rs
@@ -123,6 +123,6 @@ fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
 }
 
 fn game_show() -> GameState {
-    println!("Appologies, this game mode has not been implemented yet.");
+    println!("Apologies, this game mode has not been implemented yet.");
     return handle_user_action();
 }

--- a/src/gamemaker.rs
+++ b/src/gamemaker.rs
@@ -37,7 +37,7 @@ fn handle_user_action() -> GameState {
 
 // main loop for switching between game states
 pub fn main_loop(arg_file: Option<String>) {
-    //     tools::clear_terminal();
+    tools::clear_terminal();
     let mut game_state: GameState = match arg_file {
         Some(arg_file) => {
             let file_path: &Path = Path::new(&arg_file);
@@ -47,7 +47,7 @@ pub fn main_loop(arg_file: Option<String>) {
         None => start_up_screen(),
     };
     loop {
-        //     tools::clear_terminal();
+        tools::clear_terminal();
 
         game_state = match game_state {
             GameState::StartUpScreen => start_up_screen(),
@@ -72,7 +72,7 @@ fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
     match saved_quiz {
         None => {}
         Some(_) => {
-            println!("We have a saved quiz!!");
+            println!("Loading saved quiz file, quiz will begin immeditaly.");
             let quiz = saved_quiz.unwrap();
             println!("{:?}", quiz);
             return handle_user_action();
@@ -102,8 +102,11 @@ fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
     }
 
     let quiz = quiz.unwrap();
-    if let Some(score) = riddler::Quiz::take_quiz(quiz.clone()) {
-        riddler::Quiz::show_result(score, quiz.questions.len() as i32);
+    // get this before you tear apart the loaded quiz
+    let total_quiz_question = quiz.get_quiz_length();
+
+    if let Some(score) = riddler::Quiz::take_quiz(quiz, None) {
+        riddler::Quiz::show_result(score, total_quiz_question);
     } else {
         return GameState::QuitGame;
     }

--- a/src/gamemaker.rs
+++ b/src/gamemaker.rs
@@ -1,4 +1,6 @@
-use rust_quiz_game::riddler;
+use std::path::Path;
+
+use rust_quiz_game::riddler::{self, SavedQuiz};
 
 #[path = "tools.rs"]
 mod tools;
@@ -8,7 +10,6 @@ enum GameState {
     StartUpScreen,
     SingleExamination,
     GameShow,
-    SaveAndQuit, // watch for save and quit on other states.
     QuitGame,
 }
 
@@ -29,28 +30,29 @@ fn handle_user_action() -> GameState {
             "start up screen" => return GameState::StartUpScreen,
             "single examination" => return GameState::SingleExamination,
             "game show" => return GameState::GameShow,
-            "save and quit" => return GameState::SaveAndQuit,
             _ => println!("not a valid action, please enter one of the game modes as displayed."),
         }
     }
 }
 
 // main loop for switching between game states
-pub fn main_loop() {
-    let mut game_state: GameState = GameState::StartUpScreen;
+pub fn main_loop(arg_file: Option<String>) {
+    let game_state: GameState = match arg_file {
+        Some(String) => single_examination(Some(saved_quiz)),
+        None => start_up_screen(),
+    };
     // add load save here if available
     loop {
         // should have a shell reset here to keep things clean
         for _ in 0..3 {
             println!(); // TODO: replace with bash reset
         }
-        match game_state {
-            GameState::StartUpScreen => game_state = start_up_screen(),
-            GameState::SingleExamination => game_state = single_examination(),
-            GameState::GameShow => game_state = game_show(),
-            GameState::SaveAndQuit => game_state = save_and_quit(),
+        let game_state: GameState = match game_state {
+            GameState::StartUpScreen => start_up_screen(),
+            GameState::SingleExamination => single_examination(None),
+            GameState::GameShow => game_show(),
             GameState::QuitGame => break,
-        }
+        };
     }
     println!("Thank you for playing!");
 }
@@ -64,7 +66,7 @@ fn start_up_screen() -> GameState {
 
 /// Game state - Single Examination
 /// Guides user through quiz, prompts for every question and returns result upon completion.
-fn single_examination() -> GameState {
+fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
     let quizes = riddler::Quizes::setup_single_examination();
     let mut quiz: Option<riddler::Quiz>;
 
@@ -73,8 +75,12 @@ fn single_examination() -> GameState {
 
     loop {
         let quizes = riddler::Quizes::setup_single_examination();
-        println!("Please enter one of the above displayed quizes to start");
+        println!("Please enter one of the above displayed quizes to start, or return by entering 'start up screen'");
         let user_input = tools::read_input();
+
+        if user_input == "start up screen" {
+            return GameState::StartUpScreen;
+        }
 
         quiz = quizes.ready_quiz(user_input);
         if quiz.is_none() {
@@ -91,11 +97,6 @@ fn single_examination() -> GameState {
 }
 
 fn game_show() -> GameState {
-    println!("Appologies, this game mode has not been implemented yet.");
-    return handle_user_action();
-}
-
-fn save_and_quit() -> GameState {
     println!("Appologies, this game mode has not been implemented yet.");
     return handle_user_action();
 }

--- a/src/gamemaker.rs
+++ b/src/gamemaker.rs
@@ -24,7 +24,6 @@ fn handle_user_action() -> GameState {
 
         let user_action = tools::read_input();
 
-        println!();
         match user_action.as_str() {
             "exit" => return GameState::QuitGame,
             "start up screen" => return GameState::StartUpScreen,
@@ -70,17 +69,7 @@ fn start_up_screen() -> GameState {
 /// Guides user through quiz, prompts for every question and returns result upon completion.
 fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
     let mut answered_questions_record: Option<Vec<(String, bool)>> = None;
-    // match saved_quiz {
-    //     None => {}
-    //     Some(_) => {
-    //         println!("Loading saved quiz file, quiz will begin immeditaly.");
-    //         let quiz = saved_quiz.unwrap();
-    //         println!("{:?}", quiz);
-    //         return handle_user_action();
-    //     }
-    // }
 
-    let quizes = riddler::Quizes::setup_single_examination(); // TODO: CONFIRM YOU NEED THIS
     let quiz: Option<riddler::Quiz> = match saved_quiz {
         None => None,
         Some(_) => {
@@ -92,10 +81,9 @@ fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
         }
     };
 
-    // let quizes = riddler::Quizes::setup_single_examination();
-    // let mut quiz: Option<riddler::Quiz>;
     let quiz: riddler::Quiz = match quiz {
         None => {
+            let quizes = riddler::Quizes::setup_single_examination();
             println!("Quizes available for testing:");
             quizes.display_quiz_names();
             let selected_quiz: riddler::Quiz;
@@ -122,7 +110,6 @@ fn single_examination(saved_quiz: Option<SavedQuiz>) -> GameState {
         Some(quiz) => quiz,
     };
 
-    // get this before you tear apart the loaded quiz
     let total_quiz_question = quiz.get_quiz_length();
 
     if let Some(score) = riddler::Quiz::take_quiz(quiz, answered_questions_record) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,5 @@
 #[path = "riddler.rs"]
 pub mod riddler;
+
+#[path = "tools.rs"]
+pub mod tools;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 mod gamemaker;
 
 fn main() {
-    gamemaker::main_loop();
+    gamemaker::main_loop(None);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,26 @@
 mod gamemaker;
 
+use std::{env, io};
 fn main() {
-    gamemaker::main_loop(None);
+    let args: Vec<String> = env::args().collect();
+
+    match read_args(&args) {
+        Ok(None) => gamemaker::main_loop(None),
+        Ok(any_string) => gamemaker::main_loop(any_string),
+        Err(e) => {
+            println!("{e}");
+        }
+    }
+
+    dbg!(&args[1]);
+}
+
+fn read_args(args: &[String]) -> Result<Option<String>, String> {
+    if args.len() == 1 {
+        Ok(None)
+    } else if args.len() == 2 {
+        return Ok(Some(args[1].clone()));
+    } else {
+        return Err("To many arguments, not supported.".to_string());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod gamemaker;
 
-use std::{env, io};
+use std::env;
 fn main() {
     let args: Vec<String> = env::args().collect();
 
@@ -11,8 +11,6 @@ fn main() {
             println!("{e}");
         }
     }
-
-    dbg!(&args[1]);
 }
 
 fn read_args(args: &[String]) -> Result<Option<String>, String> {

--- a/src/quizes/jordy_test.toml
+++ b/src/quizes/jordy_test.toml
@@ -56,7 +56,7 @@ quiz_name = "How well do you know Jordy?"
     answer4 = "Gold"
     correct_answer = 2
 
-    [questions.question8] **
+    [questions.question8]
     question = "According to speculations formed by Julius, EE Teams first co-op, what criminal organization is Jordy a part of?" 
     answer1 = "Solomon Organization"
     answer2 = "Crips"

--- a/src/riddler.rs
+++ b/src/riddler.rs
@@ -1,3 +1,4 @@
+use crate::tools;
 use chrono::Local;
 use rand::prelude::SliceRandom;
 use rand::{thread_rng, Rng};
@@ -6,9 +7,6 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::{fs, fs::File, path::Path};
 use toml;
-
-#[path = "tools.rs"]
-mod tools;
 
 /// Load a toml quiz file into memory
 pub fn load_single_exam_save_file(path: &Path) -> SavedQuiz {

--- a/src/riddler.rs
+++ b/src/riddler.rs
@@ -4,6 +4,7 @@ use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Write;
+use std::path;
 use std::{fs, fs::File, path::Path};
 use toml;
 
@@ -11,7 +12,7 @@ use toml;
 mod tools;
 
 /// Load a toml quiz file into memory
-pub fn load_single_exam_save_file(path: String) -> SavedQuiz {
+pub fn load_single_exam_save_file(path: &Path) -> SavedQuiz {
     // TODO: Convert to file path
     let toml_str = fs::read_to_string(path).expect("Failed to read toml file");
     let saved_quiz: SavedQuiz = toml::from_str(&toml_str).expect("Failed to deserialize toml file");
@@ -40,7 +41,7 @@ pub fn create_and_save_single_exam_save_file(
     Ok(file_name)
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct SavedQuiz {
     ordered_quiz: Quiz,
     answered_questions: Vec<(String, bool)>, // question name and if answered correctly.
@@ -112,7 +113,7 @@ impl Quiz {
                     continue;
                 }
                 None => {
-                    save_and_quit_prompt = false;
+                    save_and_quit_prompt = true;
                     break;
                 }
             }
@@ -132,7 +133,7 @@ impl Quiz {
         Some(score)
     }
     pub fn show_result(score: i32, total_questions: i32) {
-        tools::clear_terminal();
+        //     tools::clear_terminal();
         let grade_number = score * 100 / total_questions;
         fn _print_random_grade_message(grade: char) {
             let a = vec![
@@ -278,7 +279,7 @@ pub struct Question {
 
 impl Question {
     fn ask_question(&self) -> Option<bool> {
-        tools::clear_terminal();
+        //     tools::clear_terminal();
         println!("{}", self.question);
 
         // shuffle order of answers to be displayed with an answer key to reference later when
@@ -302,10 +303,12 @@ impl Question {
             println!("[{}] {}", answer.0 + 1, answer.1);
         }
         println!("Enter the number next to the answer you beleive is correct.");
+        println!("Type 'save and quit' if you would like to do so.");
         loop {
             let user_input = tools::read_input();
 
             if user_input == "save and quit" {
+                println!("Beginning save and quit functionality...");
                 return None; // begin generating save file.
             }
             let user_answer: usize = match user_input.parse() {

--- a/src/riddler.rs
+++ b/src/riddler.rs
@@ -81,7 +81,6 @@ impl Quizes {
         for single_quiz in self.available_quizes {
             if input_quiz_name == single_quiz.quiz_name.trim().to_lowercase() {
                 quiz = Some(single_quiz.clone());
-                println!(); // spacing
             }
         }
 
@@ -133,7 +132,7 @@ impl Quiz {
         Some(score)
     }
     pub fn show_result(score: i32, total_questions: i32) {
-        println!(); // spacing
+        tools::clear_terminal();
         let grade_number = score * 100 / total_questions;
         fn _print_random_grade_message(grade: char) {
             let a = vec![
@@ -261,7 +260,9 @@ impl Quiz {
             }
             _ => unreachable!(),
         }
-        println!() // spacing
+        for _ in 0..3 {
+            println!();
+        }
     }
 }
 
@@ -277,7 +278,7 @@ pub struct Question {
 
 impl Question {
     fn ask_question(&self) -> Option<bool> {
-        // this should be referenced, but moves the question here. i think. though its in a loop so it being in a different scope pretty much does that already.
+        tools::clear_terminal();
         println!("{}", self.question);
 
         // shuffle order of answers to be displayed with an answer key to reference later when
@@ -298,7 +299,7 @@ impl Question {
         }
 
         for answer in answers.iter().enumerate() {
-            println!("[{}] {}", answer.0, answer.1);
+            println!("[{}] {}", answer.0 + 1, answer.1);
         }
         println!("Enter the number next to the answer you beleive is correct.");
         loop {
@@ -321,7 +322,7 @@ impl Question {
                 continue;
             }
             println!();
-            if shuffle_answer_key[user_answer] == self.correct_answer {
+            if shuffle_answer_key[user_answer - 1] == self.correct_answer {
                 return Some(true);
             } else {
                 return Some(false);

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+/// Generic function to ask user for input, trimed and lowercased.
 pub fn read_input() -> String {
     let mut input = String::new();
     io::stdin()
@@ -9,6 +10,7 @@ pub fn read_input() -> String {
     String::from(input.trim()).to_lowercase()
 }
 
+/// Generic function to position terminal to only show most recent information.
 pub fn clear_terminal() {
     print!("\x1B[2J\x1B[1;1H");
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -8,3 +8,7 @@ pub fn read_input() -> String {
 
     String::from(input.trim()).to_lowercase()
 }
+
+pub fn clear_terminal() {
+    print!("\x1B[2J\x1B[1;1H");
+}


### PR DESCRIPTION
Had to add in a struct for serialization and deserialization purposes, but this handles saving and loading progress on a single examination. I tried to keep the base functionality as much as possible but I quickly fell into issues that led me to change some things. Most of it is just returning options for handling another case. On that front options are super cool. 

also added a clear terminal function that doesn't clear the terminal but moves the terminal up to where the game is, leaving some spacing between the last output as well. 

Also moved around some stuff into lib to get rid of unused code errors. probably not the best move but it seems to work fine. 
